### PR TITLE
Attempt to fix the normalization bug

### DIFF
--- a/R/RcppRoll.R
+++ b/R/RcppRoll.R
@@ -22,7 +22,7 @@
 #' @param partial Partial application? Currently unimplemented.
 #' @param align Align windows on the \code{"left"}, \code{"middle"} or
 #'   \code{"right"}.
-#' @param normalize Normalize window weights, such that they sum to \code{n}.
+#' @param normalize Default is \code{TRUE}. Normalize window weights, such that they sum to \code{n=length(weights)}. 
 #' @param na.rm Remove missing values?
 NULL
 #' @rdname RcppRoll-exports

--- a/src/RcppRoll.cpp
+++ b/src/RcppRoll.cpp
@@ -99,14 +99,25 @@ T roll_vector_with(Callable f,
                    bool partial,
                    String const& align,
                    bool normalize) {
+  
+  
+  
 
-  // Normalize 'n' to match that of weights
-  if (weights.size())
-    n = weights.size();
-
-  if (normalize && weights.size())
-    weights = weights / sum(weights) * n;
-
+  if (normalize && weights.size()){
+    // Normalize 'n' to match that of weights
+    if (weights.size()){
+      n = weights.size();
+    }
+    
+    //Create a local copy of the weight vectors
+    NumericVector weights_normalized = weights / sum(weights) * n;
+    
+    return fill.filled() ?
+    roll_vector_with_fill(f, x, n, weights_normalized, by, fill, partial, align) :
+    roll_vector_with_nofill(f, x, n, weights_normalized, by, fill, partial, align)
+  ;
+  }
+  
   return fill.filled() ?
     roll_vector_with_fill(f, x, n, weights, by, fill, partial, align) :
     roll_vector_with_nofill(f, x, n, weights, by, fill, partial, align)


### PR DESCRIPTION

Please note that I do not have a cpp environment to test here at work.
This is my try, although I couldn't test.

Changes in the R file are just to make the Roxygen documentation clearer  ;
Changes in the cpp file: only changing when there is a normalization needed, creating a local variable which is then taken by reference as in your original code, hence the special return inside the 'if normalize'

Related to issue 31
https://github.com/kevinushey/RcppRoll/issues/31